### PR TITLE
新規投稿時のメール送信機能の実装

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -37,6 +37,7 @@ class TasksController < ApplicationController
       return
     end
     if @task.save
+      TaskMailer.creation_email(@task).deliver_now
       redirect_to @task, notice: "タスク「#{@task.name}を登録しました。」"
     else
       render :new, status: :unprocessable_entity

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: "taskleaf@example.com"
   layout "mailer"
 end

--- a/app/mailers/task_mailer.rb
+++ b/app/mailers/task_mailer.rb
@@ -1,0 +1,10 @@
+class TaskMailer < ApplicationMailer
+  def creation_email(task)
+    @task = task
+    mail(
+      subject: 'タスク作成完了メール',
+      to: 'user@example.com',
+      from: 'taskleaf@example.com'
+    )
+  end
+end

--- a/app/views/task_mailer/creation_email.html.slim
+++ b/app/views/task_mailer/creation_email.html.slim
@@ -1,0 +1,8 @@
+| 以下のタスクを作成しました
+ul 
+  li 
+    | 名称:
+    = @task.name
+  li 
+    | 詳しい説明:
+    = simple_format(@task.description)

--- a/app/views/task_mailer/creation_email.text.slim
+++ b/app/views/task_mailer/creation_email.text.slim
@@ -1,0 +1,8 @@
+| 以下のタスクを作成しました
+= "\n"
+| 名称:
+= @task.name
+= "\n"
+| 詳しい説明:
+= "\n"
+= simple_format(@task.description)

--- a/app/views/tasks/confirm_new.html.slim
+++ b/app/views/tasks/confirm_new.html.slim
@@ -10,5 +10,5 @@ h1 登録内容の確認
         th= Task.human_attribute_name(:description)
         td= simple_format(@task.description)
         = f.hidden_field :description
-  = f.submit '戻る', name: 'back', class: 'btn btn-secondary mr-3'
+  = f.submit '戻る', name: 'back', class: 'btn btn-secondary me-3'
   = f.submit '登録', class: 'btn btn-primary'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,7 +39,9 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.perform_caching = false
+  config.action_mailer.delivery_method = :smtp
+
+  config.action_mailer.smtp_settings = {address: '127.0.0.1', port: 1025}
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   db:
     image: postgres:13-alpine
@@ -19,6 +18,16 @@ services:
     depends_on:
       - db
       - chrome
+      - mailcatcher
+    environment:
+      - MAILCATCHER_SMTP_PORT=1025
+      
+
+  mailcatcher:
+    image: sj26/mailcatcher
+    ports:
+      - "1080:1080"
+      - "1025:1025"
 
   chrome:
     image: seleniarm/standalone-chromium:latest

--- a/spec/mailers/previews/task_mailer_preview.rb
+++ b/spec/mailers/previews/task_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/task_mailer
+class TaskMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/task_mailer_spec.rb
+++ b/spec/mailers/task_mailer_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe TaskMailer, type: :mailer do
+  let(:task){FactoryBot.create(:task, name:'メイラーSpecを書く', description:'送信したメールの内容を確認します')}
+
+  let(:text_body) do
+    part = mail.body.parts.detect{|part| part.content_type == 'text/plain; charset=UTF-8'}
+    part.body.raw_source
+  end
+
+  let(:html_body) do
+    part = mail.body.parts.detect{|part| part.content_type == 'text/plain; charset=UTF-8'}
+    part.body.raw_source
+  end
+
+  describe '#creation_email' do
+  let(:mail){TaskMailer.creation_email(task)}
+    it '想定通りのメールが生成されている' do  
+    #ヘッダ
+      expect(mail.subject).to eq('タスク作成完了メール')
+      expect(mail.to).to eq(['user@example.com'])
+      expect(mail.from).to eq(['taskleaf@example.com'])
+
+      #text形式の本文
+      expect(text_body).to match('以下のタスクを作成しました')
+      expect(text_body).to match('メイラーSpecを書く')
+      expect(text_body).to match('送信したメールの内容を確認します')
+
+      #html形式の本文
+      expect(html_body).to match('以下のタスクを作成しました')
+      expect(html_body).to match('メイラーSpecを書く')
+      expect(html_body).to match('送信したメールの内容を確認します')
+    end
+  end
+end


### PR DESCRIPTION
変更内容
・mailcatcherを用いて、タスクの新規投稿時にメールを送信する機能を実装。

問題
・メール送信後、ブラウザで`http://127.0.0.1:1080`にアクセスすると、MailCatcherにてメールが送信されてることが確認できない。
＊なお、logを確認したところ、メールを送信する`creation_email`メソッド自体は実行されていた。
